### PR TITLE
Fix location of everyTime and add new logging features

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/ConceptScanServo.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/ConceptScanServo.java
@@ -1,5 +1,6 @@
 package org.firstinspires.ftc.teamcode;
 
+import com.qualcomm.robotcore.eventloop.opmode.Disabled;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 import com.qualcomm.robotcore.hardware.Servo;
@@ -19,6 +20,7 @@ import com.qualcomm.robotcore.hardware.Servo;
  * Remove or comment out the @Disabled line to add this opmode to the Driver Station OpMode list
  */
 @TeleOp(name = "Concept: Scan Servo", group = "Concept")
+@Disabled
 public class ConceptScanServo extends LinearOpMode {
 
     static final double INCREMENT = 0.01;     // amount to slew servo each CYCLE_MS cycle

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/DataLogger.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/DataLogger.java
@@ -6,6 +6,10 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Locale;
 
 /**
  * Created by Olavi Kamppari on 9/9/2015.
@@ -20,10 +24,13 @@ public class DataLogger {
     private StringBuffer lineBuffer;
     private long msBase;
     private long nsBase;
+    static private final boolean ENABLE_LOGGING = true;
+    static private final boolean ENABLE_MULTIPLE_LOGS = true;
 
     public DataLogger(String dirName, String fileName) {
 
-        // return;
+
+        if(!ENABLE_LOGGING) {return;}
 
         //    telemetry.addData("00:DataLogger","Invoked...");
 
@@ -32,6 +39,13 @@ public class DataLogger {
             //        telemetry.addData("00:DataLogger","ExternalStorage is writeable");
         } else {
             //        telemetry.addData("00:DataLogger","ExternalStorage is NOT writeable");
+        }
+
+        if(ENABLE_MULTIPLE_LOGS) {
+            Date now = Calendar.getInstance().getTime();
+            // (2) create a date "formatter" (the date and time format we want)
+            SimpleDateFormat formatter = new SimpleDateFormat("yyyyMMddHHmmss", Locale.US);
+            fileName = fileName + "-" + formatter.format(now);
         }
 
         File logdir = new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS), dirName);
@@ -60,6 +74,9 @@ public class DataLogger {
     private void flushLineBuffer() {
         long milliTime, nanoTime;
 
+
+        if(!ENABLE_LOGGING) {return;}
+
         try {
             lineBuffer.append('\n');
             writer.write(lineBuffer.toString());
@@ -69,12 +86,15 @@ public class DataLogger {
         }
         milliTime = System.currentTimeMillis();
         nanoTime = System.nanoTime();
-        addField(String.format("%.3f", (milliTime - msBase) / 1.0E3));
-        addField(String.format("%.3f", (nanoTime - nsBase) / 1.0E6));
+        addField(String.format(Locale.US, "%.3f", (milliTime - msBase) / 1.0E3));
+        addField(String.format(Locale.US, "%.3f", (nanoTime - nsBase) / 1.0E6));
         nsBase = nanoTime;
     }
 
     public void closeDataLogger() {
+
+        if(!ENABLE_LOGGING) {return;}
+
         try {
             writer.close();
         } catch (IOException e) {
@@ -82,6 +102,9 @@ public class DataLogger {
     }
 
     public void addField(String s) {
+
+        if(!ENABLE_LOGGING) {return;}
+
         if (lineBuffer.length() > 0) {
             lineBuffer.append(',');
         }
@@ -89,6 +112,9 @@ public class DataLogger {
     }
 
     public void addField(char c) {
+
+        if(!ENABLE_LOGGING) {return;}
+
         if (lineBuffer.length() > 0) {
             lineBuffer.append(',');
         }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/DataLogger.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/DataLogger.java
@@ -2,6 +2,8 @@ package org.firstinspires.ftc.teamcode;
 
 import android.os.Environment;
 
+import org.firstinspires.ftc.robotcore.external.Telemetry;
+
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -27,19 +29,21 @@ public class DataLogger {
     static private final boolean ENABLE_LOGGING = true;
     static private final boolean ENABLE_MULTIPLE_LOGS = true;
 
-    public DataLogger(String dirName, String fileName) {
+    public DataLogger(String dirName, String fileName, Telemetry telemetry) {
 
 
         if(!ENABLE_LOGGING) {return;}
 
-        //    telemetry.addData("00:DataLogger","Invoked...");
+            telemetry.addData("00:DataLogger","Invoked...");
 
         String state = Environment.getExternalStorageState();
-        if (Environment.MEDIA_MOUNTED.equals(state)) {
-            //        telemetry.addData("00:DataLogger","ExternalStorage is writeable");
+
+/*        if (Environment.MEDIA_MOUNTED.equals(state)) {
+                    telemetry.addData("01:DataLogger","ExternalStorage is writeable");
         } else {
-            //        telemetry.addData("00:DataLogger","ExternalStorage is NOT writeable");
+                    telemetry.addData("01:DataLogger","ExternalStorage is NOT writeable");
         }
+*/
 
         if(ENABLE_MULTIPLE_LOGS) {
             Date now = Calendar.getInstance().getTime();
@@ -49,13 +53,17 @@ public class DataLogger {
         }
 
         File logdir = new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS), dirName);
+ //       telemetry.addData("02:DataLogger", Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS) + "/" + dirName);
         File logfile = new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS), dirName + "/" + fileName + ".csv");
+ //       telemetry.addData("03:DataLogger", Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS) + dirName + "/" + fileName + ".csv");
 
+/*
         if (!logdir.mkdirs()) {
-            //       telemetry.addData("00:DataLogger", "Directory not created");
+                   telemetry.addData("05:DataLogger", "Directory not created");
         } else {
-            //       telemetry.addData("00:DataLogger", "Directory is created");
+                   telemetry.addData("05:DataLogger", "Directory is created");
         }
+*/
 
         // Make sure that the directory exists
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/MultiplexColorSensor.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/MultiplexColorSensor.java
@@ -30,6 +30,10 @@ import com.qualcomm.robotcore.hardware.I2cDevice;
 import com.qualcomm.robotcore.hardware.I2cDeviceSynch;
 import com.qualcomm.robotcore.hardware.I2cDeviceSynchImpl;
 
+import java.util.Locale;
+
+import static org.firstinspires.ftc.teamcode.robotconfig.dl;
+
 /**
  * Created by Chris D on 10/5/2016.
  * <p>
@@ -152,6 +156,8 @@ public class MultiplexColorSensor {
         for (int i = 0; i < 4; i++) {
             crgb[i] = (adaCache[2 * i] & 0xFF) + (adaCache[2 * i + 1] & 0xFF) * 256;
         }
+
+        robotconfig.addlog(dl, "read color sensor port: crgb", String.format(Locale.ENGLISH, "%d: %d %d %d %d", port, crgb[0], crgb[1], crgb[2], crgb[3]));
         return crgb;
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/MultiplexColorSensorTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/MultiplexColorSensorTest.java
@@ -24,6 +24,7 @@
 
 package org.firstinspires.ftc.teamcode;
 
+import com.qualcomm.robotcore.eventloop.opmode.Disabled;
 import com.qualcomm.robotcore.eventloop.opmode.OpMode;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 
@@ -35,6 +36,7 @@ import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
  * Adafruit color sensors plugged into the I2C multiplexer on ports 2 and 5.
  */
 @TeleOp(name = "MultiplexColorSensorTest", group = "Iterative Opmode")
+@Disabled
 public class MultiplexColorSensorTest extends OpMode {
     MultiplexColorSensor muxColor;
     int[] ports = {2, 5};

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/antiSpin.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/antiSpin.java
@@ -1,6 +1,7 @@
 package org.firstinspires.ftc.teamcode;
 
 import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
+import com.qualcomm.robotcore.eventloop.opmode.Disabled;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 
 /**
@@ -8,7 +9,7 @@ import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
  */
 
 @Autonomous(name = "antiSpin", group = "2016")
-
+@Disabled
 public class antiSpin extends LinearOpMode {
     public robotconfig robot = new robotconfig();
     public preciseMovement p = new preciseMovement();

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/autonomous.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/autonomous.java
@@ -1,6 +1,7 @@
 package org.firstinspires.ftc.teamcode;
 
 import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
+import com.qualcomm.robotcore.eventloop.opmode.Disabled;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 
 import static org.firstinspires.ftc.teamcode.robotconfig.dl;
@@ -9,10 +10,7 @@ import static org.firstinspires.ftc.teamcode.robotconfig.dl;
  * Created by mail2 on 10/31/2016.
  */
 @Autonomous(name = "master autonomous program?", group = "2016")
-
-/***
- * for this file, position robot flat against wall facing center vortex
- */
+@Disabled
 public class autonomous extends LinearOpMode {
     public static int color = 1;
     public robotconfig robot = new robotconfig();

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/blueAutonomous.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/blueAutonomous.java
@@ -1,6 +1,7 @@
 package org.firstinspires.ftc.teamcode;
 
 import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
+import com.qualcomm.robotcore.eventloop.opmode.Disabled;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 
 import static org.firstinspires.ftc.teamcode.robotconfig.dl;
@@ -10,7 +11,7 @@ import static org.firstinspires.ftc.teamcode.robotconfig.dl;
  */
 
 @Autonomous(name = "legacy blue autonomous program", group = "2016")
-
+@Disabled
 public class blueAutonomous extends LinearOpMode {
     public static int color = -1;
     public robotconfig robot = new robotconfig();

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/driveToWall.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/driveToWall.java
@@ -1,6 +1,7 @@
 package org.firstinspires.ftc.teamcode;
 
 import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
+import com.qualcomm.robotcore.eventloop.opmode.Disabled;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 
 /**
@@ -8,7 +9,7 @@ import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
  */
 
 @Autonomous(name = "box drills", group = "2016")
-
+@Disabled
 public class driveToWall extends LinearOpMode {
     public robotconfig robot = new robotconfig();
     public preciseMovement p = new preciseMovement();

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/newBlueAutonomous.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/newBlueAutonomous.java
@@ -1,6 +1,7 @@
 package org.firstinspires.ftc.teamcode;
 
 import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
+import com.qualcomm.robotcore.eventloop.opmode.Disabled;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 
 import static org.firstinspires.ftc.teamcode.robotconfig.dl;
@@ -10,7 +11,7 @@ import static org.firstinspires.ftc.teamcode.robotconfig.dl;
  */
 
 @Autonomous(name = "blue autonomous program", group = "2016")
-
+@Disabled
 public class newBlueAutonomous extends LinearOpMode {
     public static int color = -1;
     public robotconfig robot = new robotconfig();

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/newredauto.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/newredauto.java
@@ -1,6 +1,7 @@
 package org.firstinspires.ftc.teamcode;
 
 import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
+import com.qualcomm.robotcore.eventloop.opmode.Disabled;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 
 import static org.firstinspires.ftc.teamcode.robotconfig.dl;
@@ -10,7 +11,7 @@ import static org.firstinspires.ftc.teamcode.robotconfig.dl;
  */
 
 @Autonomous(name = "newredauto", group = "2016")
-
+@Disabled
 public class newredauto extends LinearOpMode {
     public static int color = 1;
     public robotconfig robot = new robotconfig();

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/robotconfig.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/robotconfig.java
@@ -46,7 +46,7 @@ public class robotconfig {
     private HardwareMap hwMap = null;
     private LinearOpMode linearOpMode;
     private OpMode opMode;
-    private boolean debugMode = false;
+    private boolean debugMode = true;
     //color sensor code with multiplexor
     private int colorSensorLineThreashold = 3000;
     // The IMU sensor object
@@ -218,7 +218,7 @@ public class robotconfig {
 
         hwMap = linearOpMode.hardwareMap;
 
-        dl = new DataLogger("10635", "autonomousTest");
+        dl = new DataLogger("10635", "autonomousTest",this.linearOpMode.telemetry);
         addlog(dl, "r.init", "r.init was invoked (a)");
 
         // Define and Initialize Motors
@@ -301,7 +301,7 @@ public class robotconfig {
 
         hwMap = opMode.hardwareMap;
 
-        dl = new DataLogger("10635", "autonomousTest");
+        dl = new DataLogger("10635", "autonomousTest", opMode.telemetry);
         addlog(dl, "r.init", "r.init was invoked (a)");
 
         // Define and Initialize Motors
@@ -387,6 +387,10 @@ public class robotconfig {
      */
     void pushButton(int button) {
         addlog(dl, "robot", "pushButton was invoked");
+        if (debugMode) {
+            return;
+        }
+
         switch (button) {
             case 1:
                 buttonPusher.setPosition(1);//0.72);//right button
@@ -408,7 +412,9 @@ public class robotconfig {
     int detectColor() {
 
         addlog(dl, "robot", "detectColor was called");
-
+        if (debugMode) {
+            return(0);
+        }
         if (muxColor.getCRGB(ports[0])[1] > muxColor.getCRGB(ports[0])[3]) {
             return 1;
         } else if (muxColor.getCRGB(ports[0])[3] > muxColor.getCRGB(ports[0])[1]) {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/state.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/state.java
@@ -66,11 +66,13 @@ class state implements substate {
             robotconfig.addlog(dl, "StateMachine", "Execution of " + this.name + " has started");
             this.isFirstTime = false;
         }
-        everyTime();
+
         if (conditionsToCheck()) {
             this.onCompletion();
             currentState++;
             robotconfig.addlog(dl, "StateMachine", "Execution of " + this.name + " has been completed");
+        } else {
+            everyTime();
         }
     }
 }


### PR DESCRIPTION
Add the capability to disable logging output globally
Add the capability to have separate log files per run, instead of always overwriting the previous log
Add logging for color sensor data
Move execution of everyTime to after the test, we only want to invoke this if we have NOT met the exit conditions
Disabled non-current OpModes